### PR TITLE
Rename Open Telegram Link Method

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -78,10 +78,10 @@ public class PersonCard extends UiPart<Region> {
     }
 
     /**
-     * Opens a link to the telegram handle of {@code Person}.
+     * Opens a link to the telegram handle of {@code Person} in their preferred browser.
      */
     @FXML
-    public void openLink(ActionEvent event) {
+    public void openTelegram(ActionEvent event) {
         String telegramHandle = person.getTelegramHandle().value;
         if (telegramHandle != null && !telegramHandle.isEmpty()) {
             UiUtil.open("https://t.me/" + telegramHandle);

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,7 +28,7 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Hyperlink fx:id="name" text="\$first" styleClass="cell_big_label" onAction="#openLink"/>
+        <Hyperlink fx:id="name" text="\$first" styleClass="cell_big_label" onAction="#openTelegram"/>
       </HBox>
       <VBox spacing="3">
         <FlowPane hgap="5" alignment="CENTER_LEFT">


### PR DESCRIPTION
## Description

Inappropriate method name, quick fix, as the method only ever opens telegram links.

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->

## Checklist

- [x] I have self-reviewed my changes.
- [ ] I have added JavaDocs to all relevant methods.
- [ ] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [ ] I have updated my project portfolio with what I have contributed.
