### PR TITLE
Fix Terse English in User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -161,7 +161,7 @@ Helps user navigate through the app.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshooting](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 
 </div>
@@ -187,7 +187,7 @@ Adds a student to the student book.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshooting](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -213,7 +213,7 @@ Shows a list of all students.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshooting](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -231,7 +231,7 @@ Finds students associated with the keyword.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshooting](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -253,7 +253,7 @@ Finds students associated with the group.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems.
+Do not worry! You can refer to our [troubleshooting](#issues) guide for common problems.
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -275,7 +275,7 @@ Edits an existing student.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshooting](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -466,7 +466,7 @@ Grade a student's assignment.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshooting](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -530,7 +530,7 @@ _Details coming soon ..._
 
 --------------------------------------------------------------------------------------------------------------------
 
-## Troubleshoot
+## Troubleshooting
 <a name="issues"></a>
 
 1. **When using multiple screens**, if you move the application to a secondary screen, and later switch to using only the primary screen, the GUI will open off-screen. The remedy is to delete the `preferences.json` file created by the application before running the application again.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -148,10 +148,10 @@ Step 5 : Start using the app
 <a name="help"></a>
 ### Viewing help : `help`
 
-If you have some trouble when using `npc_track`, simply click on the help button on the top right menu bar or type 
+If you have some trouble when using `npc_track`, simply click on the help button (or F1) on the menu bar or type 
 the `help` command.
 
-Shows a message displaying the link and a button that navigates to the link directly.
+Opens the user guide in your browser.
 
 <div markdown="span" class="alert alert-success">
 :pencil2: **Purpose:**
@@ -161,7 +161,7 @@ Helps user navigate through the app.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-This is not to worry. You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 
 </div>
@@ -187,7 +187,7 @@ Adds a student to the student book.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-This is not to worry. You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -213,7 +213,7 @@ Shows a list of all students.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-This is not to worry. You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -231,7 +231,7 @@ Finds students associated with the keyword.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-This is not to worry. You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -253,7 +253,7 @@ Finds students associated with the group.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-This is not to worry. You can refer to our [troubleshoot](#issues) guide for common problems.
+Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems.
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -275,7 +275,7 @@ Edits an existing student.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-This is not to worry. You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 
@@ -466,7 +466,7 @@ Grade a student's assignment.
 </div>
 
 <div markdown="span" class="alert alert-warning">:pushpin: **Having Problems?**
-This is not to worry. You can refer to our [troubleshoot](#issues) guide for common problems. 
+Do not worry! You can refer to our [troubleshoot](#issues) guide for common problems. 
 ***Confused with some terms?*** You can refer to our [glossary](#glossary) to find out.
 </div>
 

--- a/docs/team/et-irl.md
+++ b/docs/team/et-irl.md
@@ -37,6 +37,7 @@ Given below are my contributions to the project.
 - Added the `deassign` command usage.
 - Added the `assignIndiv` command usage.
 - Spotted documentation bugs and ensured the reliability of the table of contents.
+- Scrutinised the grammar and English use in the guide.
 
 ### Contributions to the Developer Guide (DG) and UML Diagrams
 


### PR DESCRIPTION
## Description

Troubleshooting guide, not Troubleshoot guide.
![image](https://github.com/AY2324S1-CS2103T-T12-1/tp/assets/122252458/cd7f8ee5-2843-4b8e-8631-4805905a459d)

`This is not to worry.` Is extremely terse and sounds like Shakespeare or whatever.

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->

## Checklist

- [x] I have self-reviewed my changes.
- [ ] I have added JavaDocs to all relevant methods.
- [ ] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [x] I have updated my project portfolio with what I have contributed.
