### PR TITLE
Remove UI bar

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -148,8 +148,7 @@ Step 5 : Start using the app
 <a name="help"></a>
 ### Viewing help : `help`
 
-If you have some trouble when using `npc_track`, simply click on the help button (or F1) on the menu bar or type 
-the `help` command.
+If you have trouble using `npc_track`, simply type the `help` command.
 
 Opens the user guide in your browser.
 

--- a/docs/team/et-irl.md
+++ b/docs/team/et-irl.md
@@ -29,6 +29,7 @@ Given below are my contributions to the project.
   * `deassign`
   * `assignIndiv`
 - Removed the intrusive help window and made the website open immediately.
+- Removed useless top bar, as it takes up precious vertical space. The app is optimised for CLI users, so it makes no sense for a clickable bar.
 
 ### Contributions to the User Guide (UG)
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -2,12 +2,7 @@ package seedu.address.ui;
 
 import java.util.logging.Logger;
 
-import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.TextInputControl;
-import javafx.scene.input.KeyCombination;
-import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
@@ -19,7 +14,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * The Main Window. Provides the basic application layout containing
- * a menu bar and space where other JavaFX elements can be placed.
+ * a space where other JavaFX elements can be placed.
  */
 public class MainWindow extends UiPart<Stage> {
 
@@ -37,9 +32,6 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane commandBoxPlaceholder;
-
-    @FXML
-    private MenuItem helpMenuItem;
 
     @FXML
     private StackPane personListPanelPlaceholder;
@@ -62,46 +54,10 @@ public class MainWindow extends UiPart<Stage> {
 
         // Configure the UI
         setWindowDefaultSize(logic.getGuiSettings());
-
-        setAccelerators();
     }
 
     public Stage getPrimaryStage() {
         return primaryStage;
-    }
-
-    private void setAccelerators() {
-        setAccelerator(helpMenuItem, KeyCombination.valueOf("F1"));
-    }
-
-    /**
-     * Sets the accelerator of a MenuItem.
-     * @param keyCombination the KeyCombination value of the accelerator
-     */
-    private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {
-        menuItem.setAccelerator(keyCombination);
-
-        /*
-         * TODO: the code below can be removed once the bug reported here
-         * https://bugs.openjdk.java.net/browse/JDK-8131666
-         * is fixed in later version of SDK.
-         *
-         * According to the bug report, TextInputControl (TextField, TextArea) will
-         * consume function-key events. Because CommandBox contains a TextField, and
-         * ResultDisplay contains a TextArea, thus some accelerators (e.g F1) will
-         * not work when the focus is in them because the key event is consumed by
-         * the TextInputControl(s).
-         *
-         * For now, we add following event filter to capture such key events and open
-         * help window purposely so to support accelerators even when focus is
-         * in CommandBox or ResultDisplay.
-         */
-        getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            if (event.getTarget() instanceof TextInputControl && keyCombination.match(event)) {
-                menuItem.getOnAction().handle(new ActionEvent());
-                event.consume();
-            }
-        });
     }
 
     /**

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -33,14 +33,6 @@
             <Image url="@/images/header.gif" />
           </ImageView>
         </HBox>
-        <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
-          <Menu mnemonicParsing="false" text="File">
-            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-          </Menu>
-          <Menu mnemonicParsing="false" text="Help">
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
-          </Menu>
-        </MenuBar>
         <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
           <padding>
             <Insets top="10" right="10" bottom="10" left="10" />


### PR DESCRIPTION
## Description

This PR removes the top bar with File and Help. Since the app is optimised for CLI users, it makes no sense for a clickable bar above.
Furthermore, it takes up precious vertical real estate. It provides not much functionality, as `exit` and `help` already exist as typeable commands. Hence, this PR removes it.

Before:
![image](https://github.com/AY2324S1-CS2103T-T12-1/tp/assets/122252458/be4f7ef0-b7df-4451-9190-46df1a08aaea)=

After:
![image](https://github.com/AY2324S1-CS2103T-T12-1/tp/assets/122252458/46b90985-9625-4848-8c52-a6171c976c39)


## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->
Closes #148.

## Checklist

- [x] I have self-reviewed my changes.
- [ ] I have added JavaDocs to all relevant methods.
- [x] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [x] I have updated my project portfolio with what I have contributed.
