### PR TITLE
Refactor opening telegram to UiUtil

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -92,8 +92,6 @@ public class PersonCard extends UiPart<Region> {
         }
 
         String telegramHandle = person.getTelegramHandle().value;
-        if (telegramHandle != null && !telegramHandle.isEmpty()) {
-            UiUtil.open("https://t.me/" + telegramHandle);
-        }
+        UiUtil.openTelegram(telegramHandle);
     }
 }

--- a/src/main/java/seedu/address/ui/UiUtil.java
+++ b/src/main/java/seedu/address/ui/UiUtil.java
@@ -34,4 +34,14 @@ public class UiUtil {
             e.printStackTrace();
         }
     }
+
+    /**
+     * Opens a link to the telegram profile using the default web browser
+     * @param telegramHandle The telegram handle
+     */
+    public static void openTelegram(String telegramHandle) {
+        if (telegramHandle != null && !telegramHandle.isEmpty()) {
+            UiUtil.open("https://t.me/" + telegramHandle);
+        }
+    }
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request. -->
The function definition of `openTelegram()` is in the wrong location and violates OOP principles. `PersonCard.java` should never need to know how to open a telegram link. We move it to `UiUtil.java`, which is a saner choice.

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->

## Checklist

- [x] I have self-reviewed my changes.
- [x] I have added JavaDocs to all relevant methods.
- [ ] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [ ] I have updated my project portfolio with what I have contributed.
