### PR TITLE
Improve error handling

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,12 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -76,11 +76,4 @@ public class ArgumentMultimap {
         }
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/GradeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GradeCommandParser.java
@@ -38,6 +38,11 @@ public class GradeCommandParser implements Parser<GradeCommand> {
                     GradeCommand.MESSAGE_USAGE), ive);
         }
 
+        if (!argMultimap.getValue(PREFIX_NAME).isPresent() || !argMultimap.getValue(PREFIX_GRADE).isPresent()
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, GradeCommand.MESSAGE_USAGE));
+        }
+
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_GRADE);
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
@@ -64,4 +69,5 @@ public class GradeCommandParser implements Parser<GradeCommand> {
 
         return new GradeCommand(index, name, score);
     }
+
 }

--- a/src/main/java/seedu/address/logic/parser/GradeGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GradeGroupCommandParser.java
@@ -35,7 +35,14 @@ public class GradeGroupCommandParser implements Parser<GradeGroupCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     GradeGroupCommand.MESSAGE_USAGE), ive);
         }
+
+        if (!argMultimap.getValue(PREFIX_NAME).isPresent() || !argMultimap.getValue(PREFIX_GRADE).isPresent()
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, GradeGroupCommand.MESSAGE_USAGE));
+        }
+
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_GRADE);
+
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             try {
                 name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());

--- a/src/test/java/seedu/address/logic/parser/GradeCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GradeCommandParserTest.java
@@ -25,13 +25,21 @@ public class GradeCommandParserTest {
         String userInput1 = "n/Lab1";
         assertParseFailure(parser, userInput1, MESSAGE_INVALID_FORMAT);
 
-        // Test case 2: Invalid name
-        String userInput2 = "1 n/L)(&% g/sads";
-        assertParseFailure(parser, userInput2, MESSAGE_INVALID_ASSIGNMENT_NAME);
+        // Test case 2: Missing name
+        String userInput2 = "1 g/10";
+        assertParseFailure(parser, userInput2, MESSAGE_INVALID_FORMAT);
 
-        // Test case 3: Invalid score
-        String userInput3 = "1 n/Lab1 g/sads";
-        assertParseFailure(parser, userInput3, MESSAGE_INVALID_ASSIGNMENT_SCORE);
+        // Test case 3: Invalid name
+        String userInput3 = "1 n/L)(&% g/sads";
+        assertParseFailure(parser, userInput3, MESSAGE_INVALID_ASSIGNMENT_NAME);
+
+        // Test case 4: Invalid score
+        String userInput4 = "1 n/Lab1 g/sads";
+        assertParseFailure(parser, userInput4, MESSAGE_INVALID_ASSIGNMENT_SCORE);
+
+        // Test case 5: Missing grade
+        String userInput5 = "1 n/Lab1";
+        assertParseFailure(parser, userInput5, MESSAGE_INVALID_FORMAT);
 
         // Missing all index, assignment name and grade
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);

--- a/src/test/java/seedu/address/logic/parser/GradeCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GradeCommandParserTest.java
@@ -29,17 +29,9 @@ public class GradeCommandParserTest {
         String userInput2 = "1 g/10";
         assertParseFailure(parser, userInput2, MESSAGE_INVALID_FORMAT);
 
-        // Test case 3: Invalid name
-        String userInput3 = "1 n/L)(&% g/sads";
-        assertParseFailure(parser, userInput3, MESSAGE_INVALID_ASSIGNMENT_NAME);
-
-        // Test case 4: Invalid score
-        String userInput4 = "1 n/Lab1 g/sads";
-        assertParseFailure(parser, userInput4, MESSAGE_INVALID_ASSIGNMENT_SCORE);
-
-        // Test case 5: Missing grade
-        String userInput5 = "1 n/Lab1";
-        assertParseFailure(parser, userInput5, MESSAGE_INVALID_FORMAT);
+        // Test case 3: Missing grade
+        String userInput3 = "1 n/Lab1";
+        assertParseFailure(parser, userInput3, MESSAGE_INVALID_FORMAT);
 
         // Missing all index, assignment name and grade
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -59,6 +51,13 @@ public class GradeCommandParserTest {
         // Invalid score (negative value less than zero)
         assertParseFailure(parser, "1 n/Lab1 g/-10", MESSAGE_INVALID_ASSIGNMENT_SCORE);
 
+    }
+
+    @Test
+    public void parse_invalidAssignmentName_failure() {
+        // Test case 1: Invalid name
+        String userInput1 = "1 n/L)(&% g/1";
+        assertParseFailure(parser, userInput1, MESSAGE_INVALID_ASSIGNMENT_NAME);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/GradeGroupCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GradeGroupCommandParserTest.java
@@ -34,6 +34,14 @@ public class GradeGroupCommandParserTest {
         String userInput3 = "1 n/Lab1 g/sads";
         assertParseFailure(parser, userInput3, MESSAGE_INVALID_ASSIGNMENT_SCORE);
 
+        // Test case 4: Missing name
+        String userInput4 = "group g/10";
+        assertParseFailure(parser, userInput4, MESSAGE_INVALID_FORMAT);
+
+        // Test case 5: Missing grade
+        String userInput5 = "group n/Lab1";
+        assertParseFailure(parser, userInput5, MESSAGE_INVALID_FORMAT);
+
         // Missing all index, assignment name and grade
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
     }
@@ -52,6 +60,13 @@ public class GradeGroupCommandParserTest {
         // Invalid score (negative value less than zero)
         assertParseFailure(parser, "group n/Lab1 g/-10", MESSAGE_INVALID_ASSIGNMENT_SCORE);
 
+    }
+
+    @Test
+    public void parse_invalidAssignmentName_failure() {
+        // Test case 1: Invalid name
+        String userInput1 = "group tut1 n/L)(&% g/1";
+        assertParseFailure(parser, userInput1, MESSAGE_INVALID_ASSIGNMENT_NAME);
     }
 
     @Test


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request. -->
Improved the error handling message for the grade and gradeGroup in case user never put all the valid commands then error message will be thrown

![image](https://github.com/AY2324S1-CS2103T-T12-1/tp/assets/60029664/6cf653b1-4198-47a5-ac22-aa62ae3520f0)


## Context
Improved the error handling message for the grade and gradeGroup in case user never put all the valid commands then error message will be thrown. This is important 

<!-- Provide context or link to related issues, discussions, or documentation. -->

## Checklist

- [x] I have self-reviewed my changes.
- [ ] I have added JavaDocs to all relevant methods.
- [ ] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [ ] I have updated my project portfolio with what I have contributed.
