### PR TITLE
Fix participation valid range

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -412,7 +412,7 @@ Format: `inputGroupPP GROUP t/TUTORIAL pp/POINTS`
 
 `TUTORIAL`: An integer between 1 and 12 (inclusive)
 
-`POINTS`: An integer more than or equals to 0
+`POINTS`: An integer between 0 and 1000 (inclusive)
 
 Participation points can only be inputted for a tutorial that is already marked as attended.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -389,7 +389,7 @@ Format: `inputPP INDEX t/TUTORIAL pp/POINTS`
 
 `TUTORIAL`: An integer between 1 and 12 (inclusive)
 
-`POINTS`: An integer more than or equals to 0
+`POINTS`: An integer between 0 and 1000 (inclusive)
 
 Participation points can only be inputted for a tutorial that is already marked as attended.
 

--- a/docs/team/et-irl.md
+++ b/docs/team/et-irl.md
@@ -30,6 +30,7 @@ Given below are my contributions to the project.
   * `assignIndiv`
 - Removed the intrusive help window and made the website open immediately.
 - Removed useless top bar, as it takes up precious vertical space. The app is optimised for CLI users, so it makes no sense for a clickable bar.
+- Added test cases and sanity check of participation points, making sure overflow errors do not occur.
 
 ### Contributions to the User Guide (UG)
 

--- a/src/main/java/seedu/address/logic/commands/InputGroupParticipationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InputGroupParticipationCommand.java
@@ -22,6 +22,9 @@ public class InputGroupParticipationCommand extends Command {
     public static final String SUCCESS_MSG = "Participation points input successfully!";
     public static final String ATTENDANCE_NOT_MARKED = "Before inputting participation points, "
             + "mark the attendance of the student first!";
+    public static final String PARTICIPATION_POINTS_OUT_OF_RANGE = "Participation points "
+            + "must be between 0 and 1000.";
+    public static final int MAXIMUM_PARTICIPATION_POINTS = 1000;
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Inserts participation points to the group of students identified\n"
             + "by the group name used in the displayed student list.\n"
@@ -58,6 +61,10 @@ public class InputGroupParticipationCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList().filtered(x -> x.getGroup().equals(this.group));
         if (lastShownList.isEmpty()) {
             throw new CommandException(Messages.INVALID_GROUP);
+        }
+
+        if (this.points < 0 || this.points > MAXIMUM_PARTICIPATION_POINTS) {
+            throw new CommandException(PARTICIPATION_POINTS_OUT_OF_RANGE);
         }
 
         for (Person person : lastShownList) {

--- a/src/main/java/seedu/address/logic/commands/InputParticipationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InputParticipationCommand.java
@@ -21,6 +21,9 @@ public class InputParticipationCommand extends Command {
     public static final String SUCCESS_MSG = "Participation points input successfully!";
     public static final String ATTENDANCE_NOT_MARKED = "Before inputting participation points, "
             + "mark the attendance of the student first!";
+    public static final String PARTICIPATION_POINTS_OUT_OF_RANGE = "Participation points "
+            + "must be between 0 and 1000.";
+    public static final int MAXIMUM_PARTICIPATION_POINTS = 1000;
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Inserts participation points to the student identified\n"
             + "by the index number used in the displayed student list.\n"
@@ -63,6 +66,10 @@ public class InputParticipationCommand extends Command {
         Attendance studentAtd = studentToEdit.getAttendance();
         if (!studentAtd.isMarkedWeek(this.tut.getZeroBased())) {
             return new CommandResult(ATTENDANCE_NOT_MARKED);
+        }
+
+        if (this.points < 0 || this.points > MAXIMUM_PARTICIPATION_POINTS) {
+            return new CommandResult(PARTICIPATION_POINTS_OUT_OF_RANGE);
         }
 
         studentAtd.inputParticipationPoints(this.tut.getZeroBased(), this.points);

--- a/src/main/java/seedu/address/logic/commands/InputParticipationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InputParticipationCommand.java
@@ -69,7 +69,7 @@ public class InputParticipationCommand extends Command {
         }
 
         if (this.points < 0 || this.points > MAXIMUM_PARTICIPATION_POINTS) {
-            return new CommandResult(PARTICIPATION_POINTS_OUT_OF_RANGE);
+            throw new CommandException(PARTICIPATION_POINTS_OUT_OF_RANGE);
         }
 
         studentAtd.inputParticipationPoints(this.tut.getZeroBased(), this.points);

--- a/src/main/java/seedu/address/logic/parser/InputGroupParticipationParser.java
+++ b/src/main/java/seedu/address/logic/parser/InputGroupParticipationParser.java
@@ -5,11 +5,12 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PARTICIPATION_POINTS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL;
 
+import java.util.stream.Stream;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.InputGroupParticipationCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Attendance;
 import seedu.address.model.person.Group;
 
 /**
@@ -26,8 +27,11 @@ public class InputGroupParticipationParser implements Parser<InputGroupParticipa
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TUTORIAL,
                 PREFIX_PARTICIPATION_POINTS);
         Group group;
-        int tut = -1;
-        int points = -1;
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_TUTORIAL, PREFIX_PARTICIPATION_POINTS)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, InputGroupParticipationCommand.MESSAGE_USAGE));
+        }
 
         try {
             group = ParserUtil.parseGroup(argMultimap.getPreamble());
@@ -36,22 +40,17 @@ public class InputGroupParticipationParser implements Parser<InputGroupParticipa
                     InputGroupParticipationCommand.MESSAGE_USAGE), ive);
         }
 
-        if (argMultimap.getValue(PREFIX_TUTORIAL).isPresent()) {
-            tut = ParserUtil.parseTutorial(argMultimap.getValue(PREFIX_TUTORIAL).get());
-        }
-
-        if (argMultimap.getValue(PREFIX_PARTICIPATION_POINTS).isPresent()) {
-            points = ParserUtil.parseParticipationPoints(argMultimap.getValue(PREFIX_PARTICIPATION_POINTS).get());
-        }
-
-        if (tut == -1) {
-            throw new ParseException(Attendance.TUTORIAL_ERROR_MSG);
-        }
-
-        if (points == -1) {
-            throw new ParseException(Attendance.PARTICIPATION_ERROR_MSG);
-        }
+        int tut = ParserUtil.parseTutorial(argMultimap.getValue(PREFIX_TUTORIAL).get());
+        int points = ParserUtil.parseParticipationPoints(argMultimap.getValue(PREFIX_PARTICIPATION_POINTS).get());
 
         return new InputGroupParticipationCommand(group, Index.fromOneBased(tut), points);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/InputParticipationParser.java
+++ b/src/main/java/seedu/address/logic/parser/InputParticipationParser.java
@@ -5,11 +5,12 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PARTICIPATION_POINTS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL;
 
+import java.util.stream.Stream;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.InputParticipationCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Attendance;
 
 /**
  * Parses input arguments and creates a new InputParticipationCommand object
@@ -25,8 +26,11 @@ public class InputParticipationParser implements Parser<InputParticipationComman
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TUTORIAL,
                         PREFIX_PARTICIPATION_POINTS);
         Index index;
-        int tut = -1;
-        int points = -1;
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_TUTORIAL, PREFIX_PARTICIPATION_POINTS)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, InputParticipationCommand.MESSAGE_USAGE));
+        }
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -35,22 +39,19 @@ public class InputParticipationParser implements Parser<InputParticipationComman
                     InputParticipationCommand.MESSAGE_USAGE), ive);
         }
 
-        if (argMultimap.getValue(PREFIX_TUTORIAL).isPresent()) {
-            tut = ParserUtil.parseTutorial(argMultimap.getValue(PREFIX_TUTORIAL).get());
-        }
-
-        if (argMultimap.getValue(PREFIX_PARTICIPATION_POINTS).isPresent()) {
-            points = ParserUtil.parseParticipationPoints(argMultimap.getValue(PREFIX_PARTICIPATION_POINTS).get());
-        }
-
-        if (tut == -1) {
-            throw new ParseException(Attendance.TUTORIAL_ERROR_MSG);
-        }
-
-        if (points == -1) {
-            throw new ParseException(Attendance.PARTICIPATION_ERROR_MSG);
-        }
+        int tut = ParserUtil.parseTutorial(argMultimap.getValue(PREFIX_TUTORIAL).get());
+        int points = ParserUtil.parseParticipationPoints(
+                argMultimap.getValue(PREFIX_PARTICIPATION_POINTS).get());
 
         return new InputParticipationCommand(index, Index.fromOneBased(tut), points);
+    }
+
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/model/person/Attendance.java
+++ b/src/main/java/seedu/address/model/person/Attendance.java
@@ -6,7 +6,7 @@ package seedu.address.model.person;
  */
 public class Attendance {
     public static final String TUTORIAL_ERROR_MSG = "Tutorial number is out of range, should be integer between 1-12";
-    public static final String PARTICIPATION_ERROR_MSG = "PP number should be non-negative.";
+    public static final String PARTICIPATION_ERROR_MSG = "Please input a small non-negative number.";
     public static final String ORIGINAL_ATD = "0,0,0,0,0,0,0,0,0,0,0,0";
     public static final String ORIGINAL_PART = "0,0,0,0,0,0,0,0,0,0,0,0";
     private int totalTut;

--- a/src/main/java/seedu/address/model/person/Attendance.java
+++ b/src/main/java/seedu/address/model/person/Attendance.java
@@ -6,7 +6,7 @@ package seedu.address.model.person;
  */
 public class Attendance {
     public static final String TUTORIAL_ERROR_MSG = "Tutorial number is out of range, should be integer between 1-12";
-    public static final String PARTICIPATION_ERROR_MSG = "PP number is out of range, should be >= 0";
+    public static final String PARTICIPATION_ERROR_MSG = "PP number should be non-negative.";
     public static final String ORIGINAL_ATD = "0,0,0,0,0,0,0,0,0,0,0,0";
     public static final String ORIGINAL_PART = "0,0,0,0,0,0,0,0,0,0,0,0";
     private int totalTut;

--- a/src/test/java/seedu/address/logic/commands/InputGroupParticipationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/InputGroupParticipationCommandTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.InputGroupParticipationCommand.ATTENDANCE_NOT_MARKED;
+import static seedu.address.logic.commands.InputGroupParticipationCommand.MAXIMUM_PARTICIPATION_POINTS;
+import static seedu.address.logic.commands.InputGroupParticipationCommand.PARTICIPATION_POINTS_OUT_OF_RANGE;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +57,131 @@ public class InputGroupParticipationCommandTest {
         }
 
         // Check if the person's participation points have been updated for week 1
-        assertEquals(50, person.getAttendance().getParticipationPoints(0));
+        assertEquals(points, person.getAttendance().getParticipationPoints(0));
+    }
+
+    @Test
+    public void execute_validZeroPoints_inputParticipationSuccessful() {
+        // Create a sample person with attendance
+        // Group 1 corresponds to the group name
+        Group group = new Group("Group 1");
+        // create a sample person with group
+        Person person = new PersonBuilder().withGroup("Group 1")
+                .withAttendance("1,0,0,0,0,0,0,0,0,0,0,0", "0,0,0,0,0,0,0,0,0,0,0,0").build();
+        // Add the sample person to the model
+        model.addPerson(person);
+
+        // Index 1 corresponds to tut 1
+        int tut = 1;
+
+        // Points to add
+        int points = 0;
+
+        // Create a new InputParticipationCommand
+        inputGroupParticipationCommand = new InputGroupParticipationCommand(group,
+                Index.fromOneBased(tut), points);
+
+        // Execute the command
+        try {
+            inputGroupParticipationCommand.execute(model);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+
+        // Check if the person's participation points have been updated for week 1
+        assertEquals(points, person.getAttendance().getParticipationPoints(0));
+    }
+
+    @Test
+    public void execute_validMaximumPoints_inputParticipationSuccessful() {
+        // Create a sample person with attendance
+        // Group 1 corresponds to the group name
+        Group group = new Group("Group 1");
+        // create a sample person with group
+        Person person = new PersonBuilder().withGroup("Group 1")
+                .withAttendance("1,0,0,0,0,0,0,0,0,0,0,0", "0,0,0,0,0,0,0,0,0,0,0,0").build();
+        // Add the sample person to the model
+        model.addPerson(person);
+
+        // Index 1 corresponds to tut 1
+        int tut = 1;
+
+        // Points to add
+        int points = MAXIMUM_PARTICIPATION_POINTS;
+
+        // Create a new InputParticipationCommand
+        inputGroupParticipationCommand = new InputGroupParticipationCommand(group,
+                Index.fromOneBased(tut), points);
+
+        // Execute the command
+        try {
+            inputGroupParticipationCommand.execute(model);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+
+        // Check if the person's participation points have been updated for week 1
+        assertEquals(points, person.getAttendance().getParticipationPoints(0));
+    }
+
+    @Test
+    public void execute_invalidNegativePoints_inputParticipationSuccessful() {
+        // Create a sample person with attendance
+        // Group 1 corresponds to the group name
+        Group group = new Group("Group 1");
+        // create a sample person with group
+        Person person = new PersonBuilder().withGroup("Group 1")
+                .withAttendance("1,0,0,0,0,0,0,0,0,0,0,0", "0,0,0,0,0,0,0,0,0,0,0,0").build();
+        // Add the sample person to the model
+        model.addPerson(person);
+
+        // Index 1 corresponds to tut 1
+        int tut = 1;
+
+        // Points to add
+        int points = -1;
+
+        // Create a new InputParticipationCommand
+        inputGroupParticipationCommand = new InputGroupParticipationCommand(group,
+                Index.fromOneBased(tut), points);
+
+        // Execute the command and expect a error message
+        try {
+            String result = inputGroupParticipationCommand.execute(model).getFeedbackToUser();
+            assertEquals(result, PARTICIPATION_POINTS_OUT_OF_RANGE);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void execute_invalidLargePoints_inputParticipationSuccessful() {
+        // Create a sample person with attendance
+        // Group 1 corresponds to the group name
+        Group group = new Group("Group 1");
+        // create a sample person with group
+        Person person = new PersonBuilder().withGroup("Group 1")
+                .withAttendance("1,0,0,0,0,0,0,0,0,0,0,0", "0,0,0,0,0,0,0,0,0,0,0,0").build();
+        // Add the sample person to the model
+        model.addPerson(person);
+
+        // Index 1 corresponds to tut 1
+        int tut = 1;
+
+        // Points to add
+        int points = MAXIMUM_PARTICIPATION_POINTS + 1;
+
+        // Create a new InputParticipationCommand
+        inputGroupParticipationCommand = new InputGroupParticipationCommand(group,
+                Index.fromOneBased(tut), points);
+
+        // Execute the command and expect a error message
+        try {
+            String result = inputGroupParticipationCommand.execute(model).getFeedbackToUser();
+            assertEquals(result, PARTICIPATION_POINTS_OUT_OF_RANGE);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test
@@ -90,9 +216,6 @@ public class InputGroupParticipationCommandTest {
 
     @Test
     public void execute_invalidGroup_throwsCommandException() {
-        // Index 1 is invalid in an empty model
-        int index = 1;
-
         // Index 1 corresponds to tut 1
         int tut = 1;
 

--- a/src/test/java/seedu/address/logic/commands/InputParticipationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/InputParticipationCommandTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.InputParticipationCommand.ATTENDANCE_NOT_MARKED;
+import static seedu.address.logic.commands.InputParticipationCommand.MAXIMUM_PARTICIPATION_POINTS;
+import static seedu.address.logic.commands.InputParticipationCommand.PARTICIPATION_POINTS_OUT_OF_RANGE;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +57,73 @@ public class InputParticipationCommandTest {
         }
 
         // Check if the person's participation points have been updated for week 1
-        assertEquals(50, person.getAttendance().getParticipationPoints(0));
+        assertEquals(points, person.getAttendance().getParticipationPoints(0));
+    }
+
+    @Test
+    public void execute_validZeroPoints_inputParticipationSuccessful() {
+        // Create a sample person with attendance
+        Person person = new PersonBuilder().withAttendance("1,0,0,0,0,0,0,0,0,0,0,0",
+                "0,0,0,0,0,0,0,0,0,0,0,0").build();
+
+        // Add the sample person to the model
+        model.addPerson(person);
+
+        // Index 1 corresponds to the sample person
+        int index = 1;
+
+        // Index 1 corresponds to tut 1
+        int tut = 1;
+
+        // Points to add
+        int points = 0;
+
+        // Create a new InputParticipationCommand
+        inputParticipationCommand = new InputParticipationCommand(Index.fromOneBased(index),
+                Index.fromOneBased(tut), points);
+
+        // Execute the command
+        try {
+            inputParticipationCommand.execute(model);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+
+        // Check if the person's participation points have been updated for week 1
+        assertEquals(points, person.getAttendance().getParticipationPoints(0));
+    }
+
+    @Test
+    public void execute_validMaxPoints_inputParticipationSuccessful() {
+        // Create a sample person with attendance
+        Person person = new PersonBuilder().withAttendance("1,0,0,0,0,0,0,0,0,0,0,0",
+                "0,0,0,0,0,0,0,0,0,0,0,0").build();
+
+        // Add the sample person to the model
+        model.addPerson(person);
+
+        // Index 1 corresponds to the sample person
+        int index = 1;
+
+        // Index 1 corresponds to tut 1
+        int tut = 1;
+
+        // Points to add
+        int points = MAXIMUM_PARTICIPATION_POINTS;
+
+        // Create a new InputParticipationCommand
+        inputParticipationCommand = new InputParticipationCommand(Index.fromOneBased(index),
+                Index.fromOneBased(tut), points);
+
+        // Execute the command
+        try {
+            inputParticipationCommand.execute(model);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+
+        // Check if the person's participation points have been updated for week 1
+        assertEquals(points, person.getAttendance().getParticipationPoints(0));
     }
 
     @Test
@@ -103,6 +171,58 @@ public class InputParticipationCommandTest {
 
         // Execute the command and expect a CommandException
         assertThrows(CommandException.class, () -> inputParticipationCommand.execute(model));
+    }
+
+    @Test
+    public void execute_negativePoints_throwsCommandException() {
+        // Create a sample person with attendance
+        Person person = new PersonBuilder().withAttendance("1,0,0,0,0,0,0,0,0,0,0,0",
+                "0,0,0,0,0,0,0,0,0,0,0,0").build();
+
+        // Add the sample person to the model
+        model.addPerson(person);
+
+        int personIndex = 1;
+        int tutIndex = 1;
+        int points = -1;
+
+        // Create a new InputParticipationCommand
+        inputParticipationCommand = new InputParticipationCommand(Index.fromOneBased(personIndex),
+                Index.fromOneBased(tutIndex), points);
+
+        // Execute the command and expect a error message
+        try {
+            String result = inputParticipationCommand.execute(model).getFeedbackToUser();
+            assertEquals(result, PARTICIPATION_POINTS_OUT_OF_RANGE);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void execute_largePoints_throwsCommandException() {
+        // Create a sample person with attendance
+        Person person = new PersonBuilder().withAttendance("1,0,0,0,0,0,0,0,0,0,0,0",
+                "0,0,0,0,0,0,0,0,0,0,0,0").build();
+
+        // Add the sample person to the model
+        model.addPerson(person);
+
+        int personIndex = 1;
+        int tutIndex = 1;
+        int points = MAXIMUM_PARTICIPATION_POINTS + 1;
+
+        // Create a new InputParticipationCommand
+        inputParticipationCommand = new InputParticipationCommand(Index.fromOneBased(personIndex),
+                Index.fromOneBased(tutIndex), points);
+
+        // Execute the command and expect a error message
+        try {
+            String result = inputParticipationCommand.execute(model).getFeedbackToUser();
+            assertEquals(result, PARTICIPATION_POINTS_OUT_OF_RANGE);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/InputGroupParticipationParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/InputGroupParticipationParserTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.InputGroupParticipationCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Attendance;
 
 public class InputGroupParticipationParserTest {
     private static final String MESSAGE_INVALID_FORMAT =
@@ -24,7 +23,7 @@ public class InputGroupParticipationParserTest {
 
         // Test case 2: Missing week (tutorial)
         String userInput2 = "tut33";
-        assertParseFailure(parser, userInput2, Attendance.TUTORIAL_ERROR_MSG);
+        assertParseFailure(parser, userInput2, MESSAGE_INVALID_FORMAT);
 
         // Missing both group and tutorial
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -39,13 +38,13 @@ public class InputGroupParticipationParserTest {
     @Test
     public void parse_invalidTutorial_failure() {
         // Invalid tutorial (not a positive integer)
-        assertParseFailure(parser, "Group1 t/a", Attendance.TUTORIAL_ERROR_MSG);
+        assertParseFailure(parser, "Group1 t/a", MESSAGE_INVALID_FORMAT);
 
         // Invalid tutorial (0)
-        assertParseFailure(parser, "Group1 t/0", Attendance.TUTORIAL_ERROR_MSG);
+        assertParseFailure(parser, "Group1 t/0", MESSAGE_INVALID_FORMAT);
 
         // Invalid tutorial (greater than 12)
-        assertParseFailure(parser, "Group1 t/13", Attendance.TUTORIAL_ERROR_MSG);
+        assertParseFailure(parser, "Group1 t/13", MESSAGE_INVALID_FORMAT);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/InputParticipationParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/InputParticipationParserTest.java
@@ -35,13 +35,13 @@ public class InputParticipationParserTest {
     @Test
     public void parse_missingTutorial_failure() {
         // Missing tutorial
-        assertParseFailure(parser, "1 pp/50", Attendance.TUTORIAL_ERROR_MSG);
+        assertParseFailure(parser, "1 pp/50", MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_missingPoints_failure() {
         // Missing points
-        assertParseFailure(parser, "1 t/1", Attendance.PARTICIPATION_ERROR_MSG);
+        assertParseFailure(parser, "1 t/1", MESSAGE_INVALID_FORMAT);
     }
 
     @Test


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request. -->
This is with regards to `inputPP` and `inputGroupPP`.
Fixes the issue where if pp/ is not included, it would be happy.
Fixes the issue where if pp/ is `2147483647`, weird overflows can happen.

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->
Closes #166, closes #170.

## Checklist

- [ ] I have self-reviewed my changes.
- [ ] I have added JavaDocs to all relevant methods.
- [x] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [x] I have updated my project portfolio with what I have contributed.
