### PR TITLE
Assigning Large Numbers with `assign` and others

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -444,6 +444,7 @@ Examples:
 Create an assignment and assign it to all students.
 
 Format: `assign n/ASSIGNMENT_NAME m/MAX_SCORE`
+`MAX_SCORE`: An integer between 1 and 1000.
 
 Examples:
 - `assign n/Tutorial1 m/100`
@@ -464,6 +465,7 @@ Examples:
 Create an assignment and assign it to a group of students.
 
 Format: `assignGroup GROUP n/ASSIGNMENT_NAME m/MAX_SCORE`
+`MAX_SCORE`: An integer between 1 and 1000.
 
 Examples:
 - `assignGroup 1 n/Tutorial1 m/100`
@@ -474,6 +476,7 @@ Examples:
 Create an assignment and assign it to a student.
 
 Format: `assignIndiv INDEX n/ASSIGNMENT_NAME m/MAX_SCORE`
+`MAX_SCORE`: An integer between 1 and 1000.
 
 Examples:
 - `assignIndiv 1 n/Tutorial1 m/100`

--- a/docs/team/et-irl.md
+++ b/docs/team/et-irl.md
@@ -30,6 +30,8 @@ Given below are my contributions to the project.
   * `assignIndiv`
 - Removed the intrusive help window and made the website open immediately.
 - Removed useless top bar, as it takes up precious vertical space. The app is optimised for CLI users, so it makes no sense for a clickable bar.
+- Fix assignment error throwing, wrongly placed in the constructor.
+- Fix integer parsing issue, when a failed parse is detected, we should throw the specific error.
 
 ### Contributions to the User Guide (UG)
 

--- a/src/main/java/seedu/address/logic/commands/AssignmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignmentCommand.java
@@ -37,13 +37,9 @@ public class AssignmentCommand extends Command {
      * @param name The name of the assignment. Must not be null.
      * @param maxScore The maximum possible score for the assignment. Must be greater than 0.
      * @throws NullPointerException If the provided name is null.
-     * @throws IllegalArgumentException If the provided maxScore is not greater than 0.
      */
     public AssignmentCommand(Name name, int maxScore) {
         requireNonNull(name);
-        if (maxScore <= 0) {
-            throw new IllegalArgumentException("maxScore must be greater than 0");
-        }
 
         this.name = name;
         this.maxScore = maxScore;
@@ -60,6 +56,10 @@ public class AssignmentCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (maxScore <= 0 || maxScore > Assignment.MAXIMUM_ALLOWED_MAX_SCORE) {
+            throw new CommandException(Assignment.MESSAGE_INVALID_MAX_SCORE);
+        }
 
         // Loop through the list and update each person's assignments
         for (Person studentToEdit : lastShownList) {

--- a/src/main/java/seedu/address/logic/commands/AssignmentGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignmentGroupCommand.java
@@ -41,13 +41,9 @@ public class AssignmentGroupCommand extends Command {
      * @param name The name of the assignment. Must not be null.
      * @param maxScore The maximum possible score for the assignment. Must be greater than 0.
      * @throws NullPointerException If the provided name is null.
-     * @throws IllegalArgumentException If the provided maxScore is not greater than 0.
      */
     public AssignmentGroupCommand(Group group, Name name, int maxScore) {
         requireNonNull(name);
-        if (maxScore <= 0) {
-            throw new IllegalArgumentException("maxScore must be greater than 0");
-        }
 
         this.name = name;
         this.maxScore = maxScore;
@@ -67,6 +63,11 @@ public class AssignmentGroupCommand extends Command {
         if (lastShownList.isEmpty()) {
             throw new CommandException(Messages.INVALID_GROUP);
         }
+
+        if (maxScore <= 0 || maxScore > Assignment.MAXIMUM_ALLOWED_MAX_SCORE) {
+            throw new CommandException(Assignment.MESSAGE_INVALID_MAX_SCORE);
+        }
+
         // Loop through the list and update each person's assignments
         for (Person studentToEdit : lastShownList) {
             Set<Assignment> updatedAssignments = new HashSet<>();

--- a/src/main/java/seedu/address/logic/commands/AssignmentIndivCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignmentIndivCommand.java
@@ -45,9 +45,6 @@ public class AssignmentIndivCommand extends Command {
     public AssignmentIndivCommand(Index index, Name name, int maxScore) {
         requireNonNull(index);
         requireNonNull(name);
-        if (maxScore <= 0) {
-            throw new IllegalArgumentException("maxScore must be greater than 0");
-        }
 
         this.index = index;
         this.name = name;
@@ -69,6 +66,10 @@ public class AssignmentIndivCommand extends Command {
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        if (maxScore <= 0 || maxScore > Assignment.MAXIMUM_ALLOWED_MAX_SCORE) {
+            throw new CommandException(Assignment.MESSAGE_INVALID_MAX_SCORE);
         }
 
         Person studentToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/AssignmentIndivCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignmentIndivCommand.java
@@ -40,7 +40,6 @@ public class AssignmentIndivCommand extends Command {
      * @param name The name of the assignment. Must not be null.
      * @param maxScore The maximum possible score for the assignment. Must be greater than 0.
      * @throws NullPointerException If the provided name is null.
-     * @throws IllegalArgumentException If the provided maxScore is not greater than 0.
      */
     public AssignmentIndivCommand(Index index, Name name, int maxScore) {
         requireNonNull(index);

--- a/src/main/java/seedu/address/logic/parser/AssignmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignmentCommandParser.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AssignmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Assignment;
 import seedu.address.model.person.Name;
 
 
@@ -35,10 +36,12 @@ public class AssignmentCommandParser implements Parser<AssignmentCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_MAX_SCORE);
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        int maxScore = ParserUtil.parseInt(argMultimap.getValue(PREFIX_MAX_SCORE).get());
 
-        if (maxScore <= 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignmentCommand.MESSAGE_USAGE));
+        int maxScore;
+        try {
+            maxScore = ParserUtil.parseInt(argMultimap.getValue(PREFIX_MAX_SCORE).get());
+        } catch (ParseException e) {
+            throw new ParseException(Assignment.MESSAGE_INVALID_MAX_SCORE);
         }
 
         return new AssignmentCommand(name, maxScore);

--- a/src/main/java/seedu/address/logic/parser/AssignmentGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignmentGroupCommandParser.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AssignmentGroupCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Assignment;
 import seedu.address.model.person.Group;
 import seedu.address.model.person.Name;
 
@@ -31,11 +32,12 @@ public class AssignmentGroupCommandParser implements Parser<AssignmentGroupComma
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_MAX_SCORE);
         Group group = ParserUtil.parseGroup(argMultimap.getPreamble());
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        int maxScore = ParserUtil.parseInt(argMultimap.getValue(PREFIX_MAX_SCORE).get());
 
-        if (maxScore <= 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AssignmentGroupCommand.MESSAGE_USAGE));
+        int maxScore;
+        try {
+            maxScore = ParserUtil.parseInt(argMultimap.getValue(PREFIX_MAX_SCORE).get());
+        } catch (ParseException e) {
+            throw new ParseException(Assignment.MESSAGE_INVALID_MAX_SCORE);
         }
 
         return new AssignmentGroupCommand(group, name, maxScore);

--- a/src/main/java/seedu/address/logic/parser/AssignmentIndivCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignmentIndivCommandParser.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AssignmentIndivCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Assignment;
 import seedu.address.model.person.Name;
 
 
@@ -44,11 +45,12 @@ public class AssignmentIndivCommandParser implements Parser<AssignmentIndivComma
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_MAX_SCORE);
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        int maxScore = ParserUtil.parseInt(argMultimap.getValue(PREFIX_MAX_SCORE).get());
 
-        if (maxScore <= 0) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignmentIndivCommand.MESSAGE_USAGE));
+        int maxScore;
+        try {
+            maxScore = ParserUtil.parseInt(argMultimap.getValue(PREFIX_MAX_SCORE).get());
+        } catch (ParseException e) {
+            throw new ParseException(Assignment.MESSAGE_INVALID_MAX_SCORE);
         }
 
         return new AssignmentIndivCommand(index, name, maxScore);

--- a/src/main/java/seedu/address/logic/parser/GradeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GradeCommandParser.java
@@ -51,7 +51,6 @@ public class GradeCommandParser implements Parser<GradeCommand> {
             } catch (ParseException e) {
                 throw new ParseException(MESSAGE_INVALID_ASSIGNMENT_NAME);
             }
-
         }
 
         if (argMultimap.getValue(PREFIX_GRADE).isPresent()) {
@@ -60,7 +59,6 @@ public class GradeCommandParser implements Parser<GradeCommand> {
             } catch (ParseException e) {
                 throw new ParseException(MESSAGE_INVALID_ASSIGNMENT_SCORE);
             }
-
         }
 
         if (score < 0) {

--- a/src/main/java/seedu/address/model/person/Assignment.java
+++ b/src/main/java/seedu/address/model/person/Assignment.java
@@ -13,7 +13,10 @@ public class Assignment {
         "Assignments should only contain alphanumeric characters "
         + "and spaces, and it should not be blank";
 
-    public static final String MESSAGE_INVALID_SCORE = "Assignment score should be between 0 and the maximum score";
+    public static final int MAXIMUM_ALLOWED_MAX_SCORE = 1000;
+    public static final String MESSAGE_INVALID_SCORE = "Assignment score should be between 0 and the maximum score.";
+    public static final String MESSAGE_INVALID_MAX_SCORE =
+        "Assignment score should be between 1 and " + MAXIMUM_ALLOWED_MAX_SCORE + ".";
 
     /*
      * The first character of the address must not be a whitespace,


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request. -->
An `InvalidArgumentException` thrown in the constructor is not well-defined and causes runtime errors. Error handling is to be done during `execute()`.
Furthermore, the way integers are parsed makes the error message ambiguous and unuseful.

We restructure the code

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->
Closes #167.

## Checklist

- [ ] I have self-reviewed my changes.
- [x] I have added JavaDocs to all relevant methods.
- [x] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [x] I have updated my project portfolio with what I have contributed.
