### PR TITLE
Optional.ofNullable() to be used where null is allowed.

### DIFF
--- a/docs/team/et-irl.md
+++ b/docs/team/et-irl.md
@@ -30,6 +30,7 @@ Given below are my contributions to the project.
   * `assignIndiv`
 - Removed the intrusive help window and made the website open immediately.
 - Removed useless top bar, as it takes up precious vertical space. The app is optimised for CLI users, so it makes no sense for a clickable bar.
+- Fix Optionals to accept nulls using `.ofNullable()` instead of `.of()` to ensure code robustness.
 
 ### Contributions to the User Guide (UG)
 

--- a/src/main/java/seedu/address/logic/commands/AssignmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignmentCommand.java
@@ -74,9 +74,10 @@ public class AssignmentCommand extends Command {
             Person editedStudent = new Person(
                     studentToEdit.getName(), Optional.ofNullable(studentToEdit.getPhone()),
                     Optional.ofNullable(studentToEdit.getEmail()),
-                    Optional.ofNullable(studentToEdit.getTelegramHandle()), Optional.of(studentToEdit.getAttendance()),
+                    Optional.ofNullable(studentToEdit.getTelegramHandle()),
+                    Optional.ofNullable(studentToEdit.getAttendance()),
                     studentToEdit.getTags(),
-                    studentToEdit.getComments(), updatedAssignments, Optional.of(studentToEdit.getGroup()));
+                    studentToEdit.getComments(), updatedAssignments, Optional.ofNullable(studentToEdit.getGroup()));
 
             // Set the updated student in the model
             model.setPerson(studentToEdit, editedStudent);

--- a/src/main/java/seedu/address/logic/commands/AssignmentGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignmentGroupCommand.java
@@ -80,9 +80,10 @@ public class AssignmentGroupCommand extends Command {
             Person editedStudent = new Person(
                     studentToEdit.getName(), Optional.ofNullable(studentToEdit.getPhone()),
                     Optional.ofNullable(studentToEdit.getEmail()),
-                    Optional.ofNullable(studentToEdit.getTelegramHandle()), Optional.of(studentToEdit.getAttendance()),
+                    Optional.ofNullable(studentToEdit.getTelegramHandle()),
+                    Optional.ofNullable(studentToEdit.getAttendance()),
                     studentToEdit.getTags(),
-                    studentToEdit.getComments(), updatedAssignments, Optional.of(studentToEdit.getGroup()));
+                    studentToEdit.getComments(), updatedAssignments, Optional.ofNullable(studentToEdit.getGroup()));
 
             // Set the updated student in the model
             model.setPerson(studentToEdit, editedStudent);

--- a/src/main/java/seedu/address/logic/commands/AssignmentIndivCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignmentIndivCommand.java
@@ -80,11 +80,12 @@ public class AssignmentIndivCommand extends Command {
         updatedAssignments.add(newAssignment);
 
         Person editedStudent = new Person(
-                studentToEdit.getName(), Optional.of(studentToEdit.getPhone()),
-                Optional.of(studentToEdit.getEmail()),
-                Optional.of(studentToEdit.getTelegramHandle()), Optional.of(studentToEdit.getAttendance()),
+                studentToEdit.getName(), Optional.ofNullable(studentToEdit.getPhone()),
+                Optional.ofNullable(studentToEdit.getEmail()),
+                Optional.ofNullable(studentToEdit.getTelegramHandle()),
+                Optional.ofNullable(studentToEdit.getAttendance()),
                 studentToEdit.getTags(),
-                studentToEdit.getComments(), updatedAssignments, Optional.of(studentToEdit.getGroup()));
+                studentToEdit.getComments(), updatedAssignments, Optional.ofNullable(studentToEdit.getGroup()));
 
         // Set the updated student in the model
         model.setPerson(studentToEdit, editedStudent);

--- a/src/main/java/seedu/address/logic/commands/CreateGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateGroupCommand.java
@@ -47,10 +47,10 @@ public class CreateGroupCommand extends Command {
         for (Person p : lastShownList) {
             Group grp = new Group(updatedGroupName);
             if (p.getGroup().equals(new Group(groupName))) {
-                Person updatedPerson = new Person(p.getName(), Optional.of(p.getPhone()),
-                        Optional.of(p.getEmail()), Optional.of(p.getTelegramHandle()),
-                        Optional.of(p.getAttendance()), p.getTags(), p.getComments(), p.getAssignments(),
-                        Optional.of(grp));
+                Person updatedPerson = new Person(p.getName(), Optional.ofNullable(p.getPhone()),
+                        Optional.ofNullable(p.getEmail()), Optional.ofNullable(p.getTelegramHandle()),
+                        Optional.ofNullable(p.getAttendance()), p.getTags(), p.getComments(), p.getAssignments(),
+                        Optional.ofNullable(grp));
                 model.setPerson(p, updatedPerson);
                 hasUpdated = true;
             }

--- a/src/main/java/seedu/address/logic/commands/DeassignmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeassignmentCommand.java
@@ -70,11 +70,12 @@ public class DeassignmentCommand extends Command {
 
             // Create a new student with the updated assignments
             Person editedStudent = new Person(
-                    studentToEdit.getName(), Optional.of(studentToEdit.getPhone()),
-                    Optional.of(studentToEdit.getEmail()),
-                    Optional.of(studentToEdit.getTelegramHandle()), Optional.of(studentToEdit.getAttendance()),
+                    studentToEdit.getName(), Optional.ofNullable(studentToEdit.getPhone()),
+                    Optional.ofNullable(studentToEdit.getEmail()),
+                    Optional.ofNullable(studentToEdit.getTelegramHandle()),
+                    Optional.ofNullable(studentToEdit.getAttendance()),
                     studentToEdit.getTags(),
-                    studentToEdit.getComments(), updatedAssignments, Optional.of(studentToEdit.getGroup()));
+                    studentToEdit.getComments(), updatedAssignments, Optional.ofNullable(studentToEdit.getGroup()));
 
             // Set the updated student in the model
             model.setPerson(studentToEdit, editedStudent);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -118,8 +118,8 @@ public class EditCommand extends Command {
 
 
         return new Person(updatedName, Optional.ofNullable(updatedPhone), Optional.ofNullable(updatedEmail),
-                Optional.ofNullable(updatedTelegramHandle), Optional.of(updatedAttendance),
-                updatedTags, updatedComments, updatedAssignments, Optional.of(updatedGroup));
+                Optional.ofNullable(updatedTelegramHandle), Optional.ofNullable(updatedAttendance),
+                updatedTags, updatedComments, updatedAssignments, Optional.ofNullable(updatedGroup));
 
     }
 
@@ -242,7 +242,7 @@ public class EditCommand extends Command {
          * Returns {@code Optional#empty()} if {@code tags} is null.
          */
         public Optional<Set<Tag>> getTags() {
-            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+            return (tags != null) ? Optional.ofNullable(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
         /**
@@ -259,7 +259,9 @@ public class EditCommand extends Command {
          * Returns {@code Optional#empty()} if {@code comments} is null.
          */
         public Optional<Set<Assignment>> getAssignments() {
-            return (assignments != null) ? Optional.of(Collections.unmodifiableSet(assignments)) : Optional.empty();
+            return (assignments != null)
+                ? Optional.ofNullable(Collections.unmodifiableSet(assignments))
+                : Optional.empty();
         }
 
         /**
@@ -276,7 +278,7 @@ public class EditCommand extends Command {
          * Returns {@code Optional#empty()} if {@code comments} is null.
          */
         public Optional<Set<Comment>> getComments() {
-            return (comments != null) ? Optional.of(Collections.unmodifiableSet(comments)) : Optional.empty();
+            return (comments != null) ? Optional.ofNullable(Collections.unmodifiableSet(comments)) : Optional.empty();
         }
 
         /**

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -74,8 +74,8 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         Person person = new Person(name, Optional.ofNullable(phone), Optional.ofNullable(email),
-                Optional.ofNullable(telegram), Optional.of(attendance), tagList, commentList, assignmentList,
-                Optional.of(group));
+                Optional.ofNullable(telegram), Optional.ofNullable(attendance), tagList, commentList, assignmentList,
+                Optional.ofNullable(group));
 
 
         return new AddCommand(person);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -87,7 +87,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             return Optional.empty();
         }
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
+        return Optional.ofNullable(ParserUtil.parseTags(tagSet));
     }
 
 
@@ -104,6 +104,6 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         Collection<String> commentSet =
             comments.size() == 1 && comments.contains("") ? Collections.emptySet() : comments;
-        return Optional.of(ParserUtil.parseComments(commentSet));
+        return Optional.ofNullable(ParserUtil.parseComments(commentSet));
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -159,7 +159,7 @@ public class PersonBuilder {
     public Person build() {
         return new Person(name, Optional.ofNullable(phone), Optional.ofNullable(email),
                 Optional.ofNullable(telegramHandle),
-                Optional.of(attendance), tags, comments, assignments, Optional.of(group));
+                Optional.ofNullable(attendance), tags, comments, assignments, Optional.ofNullable(group));
     }
 
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request. -->
A bug report has uncovered a critical flaw in the code base, where even though users are initiated with null fields when using `add n/nameOnly`, `Optional.of()`s are constantly used in the code, which expect a non-`null` value.

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->
Closes #171.

## Checklist

- [ ] I have self-reviewed my changes.
- [ ] I have added JavaDocs to all relevant methods.
- [ ] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [x] I have updated my project portfolio with what I have contributed.
