### PR TITLE
Fix group attendance marking bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkGroupAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkGroupAttendanceCommand.java
@@ -56,10 +56,11 @@ public class MarkGroupAttendanceCommand extends Command {
             throw new CommandException(Messages.INVALID_GROUP);
         }
 
-        for (Person student : lastShownList) {
-            if (student.getAttendance().isMarkedWeek(this.tut.getZeroBased())) {
-                return new CommandResult(Messages.MESSAGE_DUPLICATE_MARKINGS);
-            }
+        boolean allStudentsHaveDuplicateMarkings = lastShownList.stream()
+            .allMatch(student -> student.getAttendance().isMarkedWeek(this.tut.getZeroBased()));
+
+        if (allStudentsHaveDuplicateMarkings) {
+            return new CommandResult(Messages.MESSAGE_DUPLICATE_MARKINGS);
         }
 
         for (Person student : lastShownList) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request. -->
We previously disallowed the group attendance marking as long as 1 person in the group already had their attendance marked.
This is incorrect logic - we should only disallow it if ALL people in the group have their attendance marked.

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->
Closes #169.

## Checklist

- [x] I have self-reviewed my changes.
- [ ] I have added JavaDocs to all relevant methods.
- [ ] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [ ] I have updated my project portfolio with what I have contributed.
