### PR TITLE
Fix edit error message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -58,8 +58,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person and telegram handle already exists "
-            + "in the address book. Either the name or telegram handle already exist";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person's name already exists.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request. -->
The edit command does not allow you to change their name if it already exists, but nothing is stopping people from having the same telegram handle. We allow the same telegram handle - this is sane, but the edit command does not seem to reflect that. We can confirm that a person can indeed have the same telegram handle by checking instances where `MESSAGE_DUPLICATE_PERSON` is thrown, and it is only when the `Person` is not "equal", which is only done by their name field.

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->
Closes #223.

## Checklist

- [x] I have self-reviewed my changes.
- [ ] I have added JavaDocs to all relevant methods.
- [ ] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [ ] I have updated my project portfolio with what I have contributed.
