### PR TITLE
Add name case insensitivity for `Person`s `Name`.

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -45,7 +45,7 @@ public class AddCommand extends Command {
             + PREFIX_NAME + "John Doe";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -59,6 +59,26 @@ public class Name {
         return fullName.equals(otherName.fullName);
     }
 
+    /**
+     * Returns true if this name is equal to another object (case-insensitive).
+     *
+     * @param other The object to compare this name to.
+     * @return True if the names are equal (case-insensitive), false otherwise.
+     */
+    public boolean equalsIgnoreCase(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Name)) {
+            return false;
+        }
+
+        Name otherName = (Name) other;
+        return fullName.toLowerCase().equalsIgnoreCase(otherName.fullName);
+    }
+
     @Override
     public int hashCode() {
         return fullName.hashCode();

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -164,7 +164,7 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+            && otherPerson.getName().equalsIgnoreCase(getName());
     }
 
     /**

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -48,6 +48,9 @@ public class NameTest {
         // same object -> returns true
         assertTrue(name.equals(name));
 
+        // different case -> returns false
+        assertFalse(name.equals(new Name("valid name")));
+
         // null -> returns false
         assertFalse(name.equals(null));
 
@@ -56,6 +59,29 @@ public class NameTest {
 
         // different values -> returns false
         assertFalse(name.equals(new Name("Other Valid Name")));
+    }
+
+    @Test
+    public void equalsIgnoreCase() {
+        Name name = new Name("Valid Name");
+
+        // same values -> returns true
+        assertTrue(name.equalsIgnoreCase(new Name("Valid Name")));
+
+        // same object -> returns true
+        assertTrue(name.equalsIgnoreCase(name));
+
+        // different case -> returns true
+        assertTrue(name.equalsIgnoreCase(new Name("valid name")));
+
+        // null -> returns false
+        assertFalse(name.equalsIgnoreCase(null));
+
+        // different types -> returns false
+        assertFalse(name.equalsIgnoreCase(5.0f));
+
+        // different values -> returns false
+        assertFalse(name.equalsIgnoreCase(new Name("Other Valid Name")));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -42,9 +42,9 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request. -->
Names shouldn't differ just because they have different casing. We change the methods to account for this.

This is a bug in AB3 [citation needed]. Hence, we could say that it is "not in scope".

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->
Closes #194. Closes #222.

## Checklist

- [x] I have self-reviewed my changes.
- [x] I have added JavaDocs to all relevant methods.
- [ ] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [ ] I have updated my project portfolio with what I have contributed.
