### PR TITLE
Add case insensitivity to status

### DIFF
--- a/src/main/java/seedu/address/model/person/Attendance.java
+++ b/src/main/java/seedu/address/model/person/Attendance.java
@@ -106,12 +106,15 @@ public class Attendance {
     }
 
     /**
-     * Checks if the status string is a valid status.
-     * @param status The status string.
-     * @return `true` if the status is valid, else `false`.
+     * Checks if a given status is valid (case-insensitive).
+     *
+     * @param status The status to check.
+     * @return True if the status is valid, false otherwise.
      */
     public static boolean isValidStatus(String status) {
-        return status.equals("P") || status.equals("A") || status.equals("VR");
+        // Convert both the input status and valid statuses to lowercase before comparing
+        String lowercaseStatus = status.toLowerCase();
+        return lowercaseStatus.equals("p") || lowercaseStatus.equals("a") || lowercaseStatus.equals("vr");
     }
 
     /**
@@ -156,7 +159,7 @@ public class Attendance {
      * @param status The status to mark the week as.
      */
     public void markAttendance(int tutorial, String status) {
-        switch(status) {
+        switch (status.toUpperCase()) {
         case "A":
             attendanceList[tutorial] = AttendanceStatus.ABSENT;
             break;

--- a/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
@@ -60,6 +60,30 @@ public class MarkAttendanceCommandTest {
     }
 
     @Test
+    public void execute_caseInsensitive_markAttendanceSuccessful() {
+        // Create a sample person with no attendance marked
+        Person person = new PersonBuilder().build();
+        model.addPerson(person);
+        int index = 1;
+        int week = 1;
+
+        String marker = "vr";
+
+        // Create a new MarkAttendanceCommand
+        markAttendanceCommand = new MarkAttendanceCommand(Index.fromOneBased(index), Index.fromOneBased(week), marker);
+
+        // Execute the command
+        try {
+            markAttendanceCommand.execute(model);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
+
+        // Check if the person's attendance has been marked for week 1
+        assertTrue(person.getAttendance().isMarkedWeek(0));
+    }
+
+    @Test
     public void execute_invalidIndex_throwsCommandException() {
         // Index 1 is invalid in an empty model
         int index = 1;

--- a/src/test/java/seedu/address/logic/parser/MarkAttendanceParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkAttendanceParserTest.java
@@ -70,5 +70,29 @@ public class MarkAttendanceParserTest {
         // Valid input with different indices and tutorial
         assertParseSuccess(parser, "2 t/5 s/P", new MarkAttendanceCommand(Index.fromOneBased(2),
                 Index.fromOneBased(5), "P"));
+
+        // Valid input with A
+        assertParseSuccess(parser, "2 t/5 s/A", new MarkAttendanceCommand(Index.fromOneBased(2),
+                Index.fromOneBased(5), "A"));
+
+        // Valid input with VR
+        assertParseSuccess(parser, "2 t/5 s/VR", new MarkAttendanceCommand(Index.fromOneBased(2),
+                Index.fromOneBased(5), "VR"));
+
+        // Valid input with case sensitivity
+        assertParseSuccess(parser, "2 t/5 s/p", new MarkAttendanceCommand(Index.fromOneBased(2),
+                Index.fromOneBased(5), "p"));
+
+        // Valid input with case sensitivity
+        assertParseSuccess(parser, "2 t/5 s/a", new MarkAttendanceCommand(Index.fromOneBased(2),
+                Index.fromOneBased(5), "a"));
+
+        // Valid input with case sensitivity
+        assertParseSuccess(parser, "2 t/5 s/vr", new MarkAttendanceCommand(Index.fromOneBased(2),
+                Index.fromOneBased(5), "vr"));
+
+        // Valid input with case sensitivity
+        assertParseSuccess(parser, "2 t/5 s/vR", new MarkAttendanceCommand(Index.fromOneBased(2),
+                Index.fromOneBased(5), "vR"));
     }
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request. -->
Please close #270 if this is merged. The `Status` field in `Attendance` when marking with `markAtd` should not be case-sensitive. i.e. `s/vr` should work exactly the same as `s/VR`, as there is no doubt that they are the same thing and would be considered a feature flaw.

Do not merge this without discussion - this may be adding a feature during the feature freeze.

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->
Closes #203

## Checklist

- [x] I have self-reviewed my changes.
- [x] I have added JavaDocs to all relevant methods.
- [ ] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [ ] I have updated my project portfolio with what I have contributed.
