### PR TITLE
Fix missing backticks in table of contents

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -399,7 +399,7 @@ For participation, you can make the following commands:
 * inputGroupPP
 * listParticipation
 
-#### Insert participation points to a student: inputPP
+#### Insert participation points to a student: `inputPP`
 <a name="inputPP"></a>
 
 input participation points for a student for that tutorial.
@@ -422,7 +422,7 @@ Examples:
 * `inputPP 1 t/1 pp/350` (For student with index 1, input 350 participation points to tutorial 1)
 * `inputPP 2 t/12 pp/500` (For student with index 2, input 500 participation points to tutorial 12)
 
-#### Insert participation points to a group of students: inputGroupPP
+#### Insert participation points to a group of students: `inputGroupPP`
 <a name="inputGroupPP"></a>
 
 input participation points for a group of students for that tutorial.


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this pull request. -->
Self explanatory, check issue.

## Context

<!-- Provide context or link to related issues, discussions, or documentation. -->
Closes #193.

## Checklist

- [ ] I have self-reviewed my changes.
- [ ] I have added JavaDocs to all relevant methods.
- [ ] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [x] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [ ] I have updated my project portfolio with what I have contributed.
