### PR TITLE
Update error message for UnmarkAttendanceParser.java

### DIFF
--- a/docs/team/proto-aiken-13.md
+++ b/docs/team/proto-aiken-13.md
@@ -28,6 +28,7 @@ Given below are my contributions to the project:
 	- Added a new parameter in the mark attendance commands (`markAtd` and `markGroupAtd`) to support a status parameter.
 	- Fix `markAtd` error throwing if the markAtd format was incorrect/missing parameters.
 	- Fix `markGroupAtd` error throwing if the markGroupAtd format format was incorrect/missing parameters.
+	- Fix `unmarkAtd` error throwing if the markGroupAtd format format was incorrect/missing parameters.
 	- Helped to add test cases to the markAttendance using partition testing principles and made sure that all inputted statuses were valid, building on the already existing test cases made by fellow teammates Choon Yan and Si Yuan.
 
 ### Contributions to the User Guide (UG)

--- a/src/main/java/seedu/address/logic/parser/UnmarkAttendanceParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkAttendanceParser.java
@@ -8,7 +8,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.UnmarkAttendanceCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Attendance;
 
 /**
  * Parses input arguments and creates a new {@code UnMarkAttendanceCommand} object
@@ -23,8 +22,12 @@ public class UnmarkAttendanceParser implements Parser<UnmarkAttendanceCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TUTORIAL);
 
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_TUTORIAL)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkAttendanceCommand.MESSAGE_USAGE));
+        }
+
         Index index;
-        int week = 0;
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (IllegalValueException ive) {
@@ -32,13 +35,7 @@ public class UnmarkAttendanceParser implements Parser<UnmarkAttendanceCommand> {
                     UnmarkAttendanceCommand.MESSAGE_USAGE), ive);
         }
 
-        if (argMultimap.getValue(PREFIX_TUTORIAL).isPresent()) {
-            week = ParserUtil.parseTutorial(argMultimap.getValue(PREFIX_TUTORIAL).get());
-        }
-
-        if (week == 0) {
-            throw new ParseException(Attendance.TUTORIAL_ERROR_MSG);
-        }
+        int week = ParserUtil.parseTutorial(argMultimap.getValue(PREFIX_TUTORIAL).get());
 
         return new UnmarkAttendanceCommand(index, Index.fromOneBased(week));
     }

--- a/src/test/java/seedu/address/logic/parser/UnmarkAttendanceParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnmarkAttendanceParserTest.java
@@ -25,10 +25,21 @@ public class UnmarkAttendanceParserTest {
 
         // Test case 2: Missing week (tutorial)
         String userInput2 = "1";
-        assertParseFailure(parser, userInput2, Attendance.TUTORIAL_ERROR_MSG);
+        assertParseFailure(parser, userInput2, MESSAGE_INVALID_FORMAT);
 
         // Missing both index and tutorial
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_incorrectParts_failure() {
+        // Test case 1: Incorrect prefix for tutorial
+        String userInput1 = "a/1";
+        assertParseFailure(parser, userInput1, MESSAGE_INVALID_FORMAT);
+
+        // Test case 2: Incorrect command in general
+        String userInput2 = "n/Homura Akemi";
+        assertParseFailure(parser, userInput2, MESSAGE_INVALID_FORMAT);
     }
 
     @Test


### PR DESCRIPTION
## Description

Amended UnmarkAttendanceParser.java to show the correct error message if any prefixes or parameters were missing/incorrect.

## Context

UnmarkAttendanceParser.java was throwing the incorrect error message if the input was invalid/not correctly formatted. The parser class has been amended accordingly to show the correct error.

Closes #202 

## Checklist

- [X] I have self-reviewed my changes.
- [X] I have added JavaDocs to all relevant methods.
- [X] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [X] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [X] I have updated my project portfolio with what I have contributed.
