### PR TITLE
Refactor MarkAttendanceParser to remove references to status == null

### DIFF
--- a/src/main/java/seedu/address/logic/parser/MarkAttendanceParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkAttendanceParser.java
@@ -9,7 +9,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.MarkAttendanceCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Attendance;
 
 /**
  * Parses input arguments and creates a new {@code MarkAttendanceCommand} object
@@ -30,8 +29,6 @@ public class MarkAttendanceParser implements Parser<MarkAttendanceCommand> {
         }
 
         Index index;
-        int tutorial = 0;
-        String status = null;
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -40,21 +37,9 @@ public class MarkAttendanceParser implements Parser<MarkAttendanceCommand> {
                     MarkAttendanceCommand.MESSAGE_USAGE), ive);
         }
 
-        if (argMultimap.getValue(PREFIX_TUTORIAL).isPresent()) {
-            tutorial = ParserUtil.parseTutorial(argMultimap.getValue(PREFIX_TUTORIAL).get());
-        }
+        int tutorial = ParserUtil.parseTutorial(argMultimap.getValue(PREFIX_TUTORIAL).get());
 
-        if (argMultimap.getValue(PREFIX_PARTICIPATION_STATUS).isPresent()) {
-            status = ParserUtil.parseParticipationStatus(argMultimap.getValue(PREFIX_PARTICIPATION_STATUS).get());
-        }
-
-        if (!(tutorial >= 1 && tutorial <= 12)) {
-            throw new ParseException(Attendance.TUTORIAL_ERROR_MSG);
-        }
-
-        if (status == null) {
-            throw new ParseException(Attendance.STATUS_ERROR_MSG);
-        }
+        String status = ParserUtil.parseParticipationStatus(argMultimap.getValue(PREFIX_PARTICIPATION_STATUS).get());
 
         return new MarkAttendanceCommand(index, Index.fromOneBased(tutorial), status);
     }


### PR DESCRIPTION

## Description

Removed the incredibly problematic status == null functionality in MarkAttendanceParser.java.


## Context

To ensure consistency with the rest of the markAttendanceParser classes, MarkAttendanceParser.java has been more condensed and all references to null checking have been removed.

## Checklist

- [X] I have self-reviewed my changes.
- [X] I have added JavaDocs to all relevant methods.
- [X] I have updated the documentation: 
  - User Guide Table of Contents, Description and Summary.
  - Developer Guide, if applicable.
- [X] I have ran `./gradlew test` or `./gradlew check` and all checks pass.
- [X] I have updated my project portfolio with what I have contributed.
